### PR TITLE
Unpin Streamlit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 bokeh==2.2.3
-streamlit==0.70.0
 streamlit-ace==0.0.4
 streamlit-metrics==0.1.0
 plotly==4.12.0


### PR DESCRIPTION
Hi there :-)

Loving your app! I was thinking we should unpin Streamlit in the requirements, so that the Streamlit version used in Cloud when (re)booting is always the latest. 

